### PR TITLE
Enable simple-theme dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,10 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="description" content="IBM i development extension for VS Code">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-    <link
-        rel="stylesheet"
-        href="https://unpkg.com/docsify-themeable/dist/css/theme-simple.css"
-    />
+    <link rel="stylesheet" media="(prefers-color-scheme: dark)" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
+    <link rel="stylesheet" media="(prefers-color-scheme: light)" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css">
     <style>
         /* cover image fix */
         


### PR DESCRIPTION
Allow simple-theme to turn dark depending on the user's preference.
For those who like to take good care of their eyeballs 😉