### PR TITLE
Add note about QCCSID

### DIFF
--- a/docs/pages/developing/sourcedates.md
+++ b/docs/pages/developing/sourcedates.md
@@ -1,7 +1,7 @@
 Source dates are supported in Code for IBM i, but not by default.
 
 ## Prerequisites to using source dates
-For source dates to be enabled, the QCCSID system value must not be 65535. Here is [IBM's page about setting QCCSID](https://www.ibm.com/docs/en/i/7.5?topic=faqs-i-system-value-qccsid).
+For source dates to be enabled, the QCCSID system value must not be 65535. See [our documentation about encoding](../tips/ccsid.md) and [IBM's documentation about the QCCSID system value](https://www.ibm.com/docs/en/i/7.5?topic=faqs-i-system-value-qccsid).
 
 ## Source date settings
 

--- a/docs/pages/developing/sourcedates.md
+++ b/docs/pages/developing/sourcedates.md
@@ -1,5 +1,8 @@
 Source dates are supported in Code for IBM i, but not by default.
 
+## Prerequisites to using source dates
+For source dates to be enabled, the QCCSID system value must not be 65535. Here is [IBM's page about setting QCCSID](https://www.ibm.com/docs/en/i/7.5?topic=faqs-i-system-value-qccsid).
+
 ## Source date settings
 
 Source dates can be enabled in the connection settings.


### PR DESCRIPTION
QCCSID must not be 65535 for source dates to be used.