### PR TITLE
Add docs for securing C4i and SSH

### DIFF
--- a/src/content/docs/tips/secure.mdx
+++ b/src/content/docs/tips/secure.mdx
@@ -9,7 +9,7 @@ Whenever Code for IBM i connects to the server, it will check for (and possibly 
 
 Raising the security level for Code for IBM i can be done by four steps:
 
-1. Create a group profile for all the Code for IBM i developers.
+1. Create a group profile for all the Code for IBM i developers. The group profile should not be granted any special authorities.
 2. Change every Code for IBM i developer to be part of the group.
 3. Make the group profile the owner of the Code for IBM i library.
 4. Exclude public access to the Code for IBM i library.

--- a/src/content/docs/tips/secure.mdx
+++ b/src/content/docs/tips/secure.mdx
@@ -1,0 +1,32 @@
+---
+title: Secure Code for IBM i on the server
+---
+
+Whenever Code for IBM i connects to the server, it will check for (and possibly create or update) some components stored in the temporary library as defined in the connection setting. These components are not secure by default and may be subject to attacks like security escalation. Developers often do not have the rights to fully set up security, and the commands in this section may require the help of (or be run by) a system or security administrator.
+
+**It is highly recommended to follow the guidelines in the following section to avoid security exposures!**
+
+
+Raising the security level for Code for IBM i can be done by four steps:
+
+1. Create a group profile for all the Code for IBM i developers.
+2. Change every Code for IBM i developer to be part of the group.
+3. Make the group profile the owner of the Code for IBM i library.
+4. Exclude public access to the Code for IBM i library.
+
+The CL commands for each step are shown in the example below. Here we create a group profile called `GRPDEV` for the developers `ALICE` and `BOB`, both using the default library ILEDITOR for Code for IBM i components:
+
+```CL
+/* Create group profile GRPDEV for Code for IBM i developers. */
+CRTUSRPRF USRPRF(GRPDEV) PASSWORD(*NONE) TEXT('Group profile for Code for IBM i developers')
+
+/* Make ALICE and BOB part of the group. */
+CHGUSRPRF USRPRF(ALICE) GRPPRF(GRPDEV)
+CHGUSRPRF USRPRF(BOB) GRPPRF(GRPDEV)
+
+/* Make the developer group profile the owner of the Code for IBM i library ILEDITOR. */
+CHGOBJOWN OBJ(ILEDITOR) OBJTYPE(*LIB) NEWOWN(GRPDEV)
+
+/* Exclude access for users not in the developer group. */
+GRTOBJAUT OBJ(ILEDITOR) OBJTYPE(*LIB) USER(*PUBLIC) AUT(*EXCLUDE)
+```

--- a/src/content/docs/tips/secure_ssh.mdx
+++ b/src/content/docs/tips/secure_ssh.mdx
@@ -1,0 +1,36 @@
+---
+title: Secure access through SSH
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="note">
+This section is for the system or security administrator, who wants to control the use of SSH.
+</Aside>
+
+Code for IBM i connects to the server via SSH, and the SSH server daemon must be running on IBM i. Since SSH is a well-known service used on all platforms, it is good practice to restrict which users can connect to IBM i via SSH.
+
+The exit points in IBM i normally used for controlling network access does not cover the SSH server. The best and simplest method
+for securing the SSH server is changing the configuration file for the service. The configuration file is found here:
+
+`/QOpenSys/QIBM/UserData/SC1/OpenSSH/etc/sshd_config`
+
+If you followed the recommendation in [Secure Code for IBM i on the server](../secure/) and created a group profile for the developers using Code for IBM i, you can add a line to the SSH server configuration to allow only users in the developer group to access the SSH server:
+
+```
+AllowGroups grpdev
+```
+
+<Aside type="note">
+The name of the group profile must be specified in lowercase!
+</Aside>
+
+SSH is used for multiple purposes - terminal access, file transfer and more. If you're using SSH with other users than Code for IBM i developers, you may already have a group profile for SSH users. In this case you can either make the Code for IBM i developers members of the SSH users group, or you can add multiple groups to the `AllowGroups` directive:
+
+```
+AllowGroups grpssh grpdev
+```
+
+Security expert Carol Woodbury has written an excellent [article](https://www.mcpressonline.com/security/ibm-i-os400-i5os/controlling-access-to-ssh-on-ibm-i) about this topic.
+
+For more information about the SSH server configuration options, see the [manual page](https://man.openbsd.org/sshd_config) for `sshd_config`.


### PR DESCRIPTION
This PR will add two pages to the Code for IBM i documentation:

<img width="315" height="417" alt="image" src="https://github.com/user-attachments/assets/7864928c-7cdd-4725-ab6a-7aefa5c66f49" />

The pages describe how to secure the Code for IBM i component library and the SSH server.