### PR TITLE
Document automatic CCSID conversion settings

### DIFF
--- a/src/content/docs/settings/connection.mdx
+++ b/src/content/docs/settings/connection.mdx
@@ -49,6 +49,20 @@ Temporary IFS directory. Stores temporary IFS files used by Code for i. Will be 
 >
 It is safe to have files created by Code for i automatically deleted during maintenance or IPL.
 
+### Automatic CCSID Conversion
+
+When checked, members with the selected Source CCSID will be converted to the configured Target CCSID when opened and saved.
+
+Useful when working with non-UTF compatible CCSIDs, especially BiDi CCSIDs.
+
+### Source CCSID
+
+The CCSID to convert from.
+
+### Target CCSID
+
+The CCSID to convert to.
+
 ### Enable source dates
 
 When checked, source dates will be retained.


### PR DESCRIPTION
### Changes
Added documentation for the Automatic CCSID Conversion settings to:

src/content/docs/settings/connection.mdx

The new section documents:

Automatic CCSID Conversion
Source CCSID
Target CCSID

It also explains when these settings should be used when working with non-UTF compatible CCSIDs, especially BiDi CCSIDs.

Related to codefori/vscode-ibmi#2826.

### How to test this PR
Review the updated connection settings documentation page.

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
