### PR TITLE
Fix formatting issue in FAQ

### DIFF
--- a/src/content/docs/developing/debug/overview.mdx
+++ b/src/content/docs/developing/debug/overview.mdx
@@ -204,9 +204,9 @@ If you find that you've added your local hostname entry and the error is still o
 **Question**: What is the JRE requirement for running the debug service?  
 **Answer**: The supported Java versions for different OS levels in Debug Service v3.0.4 and higher are::
 
-    IBM i 7.6: Java 17
-    IBM i 7.4/7.5: Java 11 and Java 17 (Default: Java 11)
-    IBM i 7.3: Java 11
+    - IBM i 7.6: Java 17 
+    - IBM i 7.4/7.5: Java 11 and Java 17 (Default: Java 11) 
+    - IBM i 7.3: Java 11 
 
 For Debug Service v3.0.0 to v3.0.3, Java 11 is required on IBM i 7.3/7.4/7.5. Java 17 is required on IBM i 7.6.
 


### PR DESCRIPTION
Text for an FAQ entry is displayed differently in the final doc page than in the preview. Use itemized list to display Java versions for multiple OS levels.