### PR TITLE
 Update HTTP Group PTF to new level

### DIFF
--- a/src/content/docs/developing/debug/configure.mdx
+++ b/src/content/docs/developing/debug/configure.mdx
@@ -20,19 +20,19 @@ To make use of the Debug Service, you need the following PTFs:
 
 * IBM i 7.6
    * Debug Service PTF SJ10811
-   * HTTP Group PTF SF99962 level 11 or higher
+   * HTTP Group PTF SF99962 level 12 or higher
    * Java 17 (LPP 5770JV1 Option 20)
 * IBM i 7.5
    * Debug Service PTF SJ10738
-   * HTTP Group PTF SF99952 level 30 or higher
+   * HTTP Group PTF SF99952 level 31 or higher
    * Java 11 (LPP 5770JV1 Option 19), or Java 17 (LPP 5770JV1 Option 20)
 * IBM i 7.4
    * Debug Service PTF SJ10718
-   * HTTP Group PTF SF99662 level 51 or higher
+   * HTTP Group PTF SF99662 level 52 or higher
    * Java 11 (LPP 5770JV1 Option 19), or Java 17 (LPP 5770JV1 Option 20)
 * IBM i 7.3
    * Debug Service PTF SJ10623
-   * HTTP Group PTF SF99722 level 67 or higher
+   * HTTP Group PTF SF99722 level 68 or higher
    * Java 11 (LPP 5770JV1 Option 19)
 
 **All OS versions require** 5770WDS option 60 (Workstation Tools - Base).


### PR DESCRIPTION
An update to HTTP Group PTF was out. We will update the HTTP Group PTF to a newer level.
