### PR TITLE
Add PTF numbers for debug service v3.0.5

### DIFF
--- a/src/content/docs/developing/debug/configure.mdx
+++ b/src/content/docs/developing/debug/configure.mdx
@@ -16,6 +16,30 @@ import { Aside, CardGrid, Card, Icon, Tabs, TabItem } from '@astrojs/starlight/c
 To make use of the Debug Service, you need the following PTFs:
 
 <Tabs>
+<TabItem label="Version 3.0.5" >
+
+* IBM i 7.6
+   * Debug Service PTF SJ11126
+   * HTTP Group PTF SF99962 level 13 or higher
+   * Java 17 (LPP 5770JV1 Option 20)
+* IBM i 7.5
+   * Debug Service PTF SJ11125
+   * HTTP Group PTF SF99952 level 32 or higher
+   * Java 11 (LPP 5770JV1 Option 19), or Java 17 (LPP 5770JV1 Option 20)
+* IBM i 7.4
+   * Debug Service PTF SJ11124
+   * HTTP Group PTF SF99662 level 53 or higher
+   * Java 11 (LPP 5770JV1 Option 19), or Java 17 (LPP 5770JV1 Option 20)
+* IBM i 7.3
+   * Debug Service PTF SJ11128
+   * HTTP Group PTF SF99722 level 69 or higher
+   * Java 11 (LPP 5770JV1 Option 19)
+
+**All OS versions require** 5770WDS option 60 (Workstation Tools - Base).
+
+<Aside type="note">You need to restart the ADMIN1 server after applying a HTTP Group PTF.</Aside>
+
+</TabItem>
 <TabItem label="Version 3.0.4" >
 
 * IBM i 7.6


### PR DESCRIPTION
Add a new tab item for debug service v3.0.5, with new PTF numbers and HTTP Group levels.